### PR TITLE
Disable setDefaultDataSubId(subId) when parameter

### DIFF
--- a/src/java/com/android/internal/telephony/SubscriptionController.java
+++ b/src/java/com/android/internal/telephony/SubscriptionController.java
@@ -35,6 +35,7 @@ import android.os.Message;
 import android.os.RemoteException;
 import android.os.ServiceManager;
 import android.os.UserHandle;
+import android.os.SystemProperties;
 import android.net.NetworkRequest;
 import android.preference.PreferenceManager;
 import android.provider.Settings.SettingNotFoundException;
@@ -59,6 +60,7 @@ import java.io.FileDescriptor;
 import java.io.PrintWriter;
 import java.lang.NumberFormatException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -816,7 +818,9 @@ public class SubscriptionController extends ISub.Stub {
                             if (DBG) {
                                 logdl("[addSubInfoRecord] one sim set defaults to subId=" + subId);
                             }
-                            setDefaultDataSubId(subId);
+			    if (!Arrays.asList("nodefaultdata").contains(SystemProperties.get("ro.telephony.ril.v3"))) {
+                                setDefaultDataSubId(subId);
+			    }
                             setDataSubId(subId);
                             setDefaultSmsSubId(subId);
                             setDefaultVoiceSubId(subId);


### PR DESCRIPTION
 ro.telephony.ril.v3 is set to nodefaultdata

For some reason the RIL for the gproj devices crash when this function is set.
With this patch setDefaultDataSubId(subId) will be disabled when ro.telephony.ril.v3 reads nodefaultdata.
When you're device gives problems with DefaultDataSubId then set ro.telephony.ril.v3 to nodefaultdata in the build.prop
Update 1: Sorry previous patch upload went wrong.

Change-Id: I7774c81bc66b57a8d5ce173bb309c8e8ebc8b039
Signed-off-by: Jan Jasper de Kroon jajadekroon@gmail.com
