### PR TITLE
Remove UICC TLV Data decoding 1/2

### DIFF
--- a/src/java/com/android/internal/telephony/uicc/IccFileHandler.java
+++ b/src/java/com/android/internal/telephony/uicc/IccFileHandler.java
@@ -359,7 +359,7 @@ public abstract class IccFileHandler extends Handler implements IccConstants {
                         fileid, 0, onLoaded);
 
         mCi.iccIOForApp(COMMAND_GET_RESPONSE, fileid, getEFPath(fileid),
-                        0, 0, 0, null, null, mAid, response);
+                        0, 0, GET_RESPONSE_EF_SIZE_BYTES, null, null, mAid, response);
     }
 
     /**
@@ -538,29 +538,16 @@ public abstract class IccFileHandler extends Handler implements IccConstants {
 
                 data = result.payload;
 
-                if (UiccTlvData.isUiccTlvData(data)) {
-                    UiccTlvData tlvData = UiccTlvData.parse(data);
-
-                    if (tlvData.isIncomplete()) {
-                        throw new IccFileTypeMismatch();
-                    }
-
-                    recordSize = new int[3];
-                    recordSize[0] = tlvData.mRecordSize;
-                    recordSize[1] = tlvData.mFileSize;
-                    recordSize[2] = tlvData.mNumRecords;
-                } else {
-                    if (TYPE_EF != data[RESPONSE_DATA_FILE_TYPE] ||
-                        EF_TYPE_LINEAR_FIXED != data[RESPONSE_DATA_STRUCTURE]) {
-                        throw new IccFileTypeMismatch();
-                    }
-
-                    recordSize = new int[3];
-                    recordSize[0] = data[RESPONSE_DATA_RECORD_LENGTH] & 0xFF;
-                    recordSize[1] = ((data[RESPONSE_DATA_FILE_SIZE_1] & 0xff) << 8)
-                           + (data[RESPONSE_DATA_FILE_SIZE_2] & 0xff);
-                    recordSize[2] = recordSize[1] / recordSize[0];
+                if (TYPE_EF != data[RESPONSE_DATA_FILE_TYPE] ||
+                    EF_TYPE_LINEAR_FIXED != data[RESPONSE_DATA_STRUCTURE]) {
+                    throw new IccFileTypeMismatch();
                 }
+
+                recordSize = new int[3];
+                recordSize[0] = data[RESPONSE_DATA_RECORD_LENGTH] & 0xFF;
+                recordSize[1] = ((data[RESPONSE_DATA_FILE_SIZE_1] & 0xff) << 8)
+                       + (data[RESPONSE_DATA_FILE_SIZE_2] & 0xff);
+                recordSize[2] = recordSize[1] / recordSize[0];
 
                 sendResult(response, recordSize, null);
                 break;
@@ -579,32 +566,20 @@ public abstract class IccFileHandler extends Handler implements IccConstants {
                 data = result.payload;
                 path = lc.mPath;
 
-                if (UiccTlvData.isUiccTlvData(data)) {
-                    UiccTlvData tlvData = UiccTlvData.parse(data);
-
-                    if (tlvData.isIncomplete()) {
-                        throw new IccFileTypeMismatch();
-                    }
-
-                    lc.mRecordSize = tlvData.mRecordSize;
-                    lc.mCountRecords = tlvData.mNumRecords;
-                    size = tlvData.mFileSize;
-                } else {
-                    if (TYPE_EF != data[RESPONSE_DATA_FILE_TYPE]) {
-                        throw new IccFileTypeMismatch();
-                    }
-
-                    if (EF_TYPE_LINEAR_FIXED != data[RESPONSE_DATA_STRUCTURE]) {
-                        throw new IccFileTypeMismatch();
-                    }
-
-                    lc.mRecordSize = data[RESPONSE_DATA_RECORD_LENGTH] & 0xFF;
-
-                    size = ((data[RESPONSE_DATA_FILE_SIZE_1] & 0xff) << 8)
-                           + (data[RESPONSE_DATA_FILE_SIZE_2] & 0xff);
-
-                    lc.mCountRecords = size / lc.mRecordSize;
+                if (TYPE_EF != data[RESPONSE_DATA_FILE_TYPE]) {
+                    throw new IccFileTypeMismatch();
                 }
+
+                if (EF_TYPE_LINEAR_FIXED != data[RESPONSE_DATA_STRUCTURE]) {
+                    throw new IccFileTypeMismatch();
+                }
+
+                lc.mRecordSize = data[RESPONSE_DATA_RECORD_LENGTH] & 0xFF;
+
+                size = ((data[RESPONSE_DATA_FILE_SIZE_1] & 0xff) << 8)
+                       + (data[RESPONSE_DATA_FILE_SIZE_2] & 0xff);
+
+                lc.mCountRecords = size / lc.mRecordSize;
 
                  if (lc.mLoadAll) {
                      lc.results = new ArrayList<byte[]>(lc.mCountRecords);
@@ -634,26 +609,16 @@ public abstract class IccFileHandler extends Handler implements IccConstants {
 
                 fileid = msg.arg1;
 
-                if (UiccTlvData.isUiccTlvData(data)) {
-                    UiccTlvData tlvData = UiccTlvData.parse(data);
-
-                    if (tlvData.mFileSize < 0) {
-                        throw new IccFileTypeMismatch();
-                    }
-
-                    size = tlvData.mFileSize;
-                } else {
-                    if (TYPE_EF != data[RESPONSE_DATA_FILE_TYPE]) {
-                        throw new IccFileTypeMismatch();
-                    }
-
-                    if (EF_TYPE_TRANSPARENT != data[RESPONSE_DATA_STRUCTURE]) {
-                        throw new IccFileTypeMismatch();
-                    }
-
-                    size = ((data[RESPONSE_DATA_FILE_SIZE_1] & 0xff) << 8)
-                           + (data[RESPONSE_DATA_FILE_SIZE_2] & 0xff);
+                if (TYPE_EF != data[RESPONSE_DATA_FILE_TYPE]) {
+                    throw new IccFileTypeMismatch();
                 }
+
+                if (EF_TYPE_TRANSPARENT != data[RESPONSE_DATA_STRUCTURE]) {
+                    throw new IccFileTypeMismatch();
+                }
+
+                size = ((data[RESPONSE_DATA_FILE_SIZE_1] & 0xff) << 8)
+                       + (data[RESPONSE_DATA_FILE_SIZE_2] & 0xff);
 
                 mCi.iccIOForApp(COMMAND_READ_BINARY, fileid, getEFPath(fileid),
                                 0, 0, size, null, null, mAid,


### PR DESCRIPTION
On some phones with implementated UICC TLV Data decoding, SIM's not recognised. With reverted commit all fine.
